### PR TITLE
ci: workflow to run second instance

### DIFF
--- a/.github/workflows/double.yml
+++ b/.github/workflows/double.yml
@@ -1,4 +1,4 @@
-name: linux
+name: double
 on: [push, pull_request]
 jobs:
   singularity:

--- a/.github/workflows/double.yml
+++ b/.github/workflows/double.yml
@@ -1,0 +1,26 @@
+name: linux
+on: [push, pull_request]
+jobs:
+  singularity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+      with:
+        cvmfs_repositories: 'singularity.opensciencegrid.org'
+    - uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        run_local_checkout: 'true'
+        platform-release: "jug_xl:nightly"
+        run: |
+          gcc --version
+          which gcc
+          eic-info
+    - uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        run_local_checkout: 'true'
+        platform-release: "jug_xl:nightly"
+        run: |
+          gcc --version
+          which gcc
+          eic-info

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -43,7 +43,7 @@ echo "Install Singularity"
 conda install --quiet --yes -c conda-forge singularity > /dev/null 2>&1
 eval "$(conda shell.bash hook)"
 
-worker=$(echo ${SANDBOX_PATH} | sha256sum)
+worker=$(echo ${SANDBOX_PATH} | sha256sum | awk '{print$1}')
 if singularity instance list | grep ${worker} ; then
   echo "Reusing exisitng Singularity image from ${SANDBOX_PATH}"
  else

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -43,11 +43,16 @@ echo "Install Singularity"
 conda install --quiet --yes -c conda-forge singularity > /dev/null 2>&1
 eval "$(conda shell.bash hook)"
 
-echo "Starting Singularity image from ${SANDBOX_PATH}"
-singularity instance start --bind /cvmfs --bind ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} ${SANDBOX_PATH} view_worker
+worker=$(echo ${SANDBOX_PATH} | sha256sum)
+if singularity instance list | grep ${worker} ; then
+  echo "Reusing exisitng Singularity image from ${SANDBOX_PATH}"
+ else
+  echo "Starting Singularity image from ${SANDBOX_PATH}"
+  singularity instance start --bind /cvmfs --bind ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} ${SANDBOX_PATH} ${worker}
+fi
 
 echo "####################################################################"
 echo "###################### Executing user payload ######################"
 echo "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV"
 
-singularity exec instance://view_worker /bin/bash -c "cd ${GITHUB_WORKSPACE}; ./action_payload.sh"
+singularity exec instance://${worker} /bin/bash -c "cd ${GITHUB_WORKSPACE}; ./action_payload.sh"


### PR DESCRIPTION
This introduces the running of multiple instances consecutively. Currently that's not possible because a single instance is started with a fixed name. We can reuse the name if it already exists.

(TDD, will fail until implemented)