### PR TITLE
ci: checkout@v3 and github-action-cvmfs@v3 (apt caching)

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -4,8 +4,8 @@ jobs:
   singularity:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
       with:
         cvmfs_repositories: 'singularity.opensciencegrid.org'
     - uses: eic/run-cvmfs-osg-eic-shell@main

--- a/.github/workflows/double.yml
+++ b/.github/workflows/double.yml
@@ -4,8 +4,8 @@ jobs:
   singularity:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
       with:
         cvmfs_repositories: 'singularity.opensciencegrid.org'
     - uses: eic/run-cvmfs-osg-eic-shell@main


### PR DESCRIPTION
This switches the CI workflows to v3 of checkout and of github-action-cvmfs (which has apt caching)