### PR TITLE
feat: allow for running jobs without network access

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -8,9 +8,8 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
       with:
         cvmfs_repositories: 'singularity.opensciencegrid.org'
-    - uses: eic/run-cvmfs-osg-eic-shell@main
+    - uses: ./
       with:
-        run_local_checkout: 'true'
         platform-release: "jug_xl:nightly"
         run: |
           gcc --version

--- a/.github/workflows/double.yml
+++ b/.github/workflows/double.yml
@@ -8,17 +8,15 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
       with:
         cvmfs_repositories: 'singularity.opensciencegrid.org'
-    - uses: eic/run-cvmfs-osg-eic-shell@main
+    - uses: ./
       with:
-        run_local_checkout: 'true'
         platform-release: "jug_xl:nightly"
         run: |
           gcc --version
           which gcc
           eic-info
-    - uses: eic/run-cvmfs-osg-eic-shell@main
+    - uses: ./
       with:
-        run_local_checkout: 'true'
         platform-release: "jug_xl:nightly"
         run: |
           gcc --version

--- a/.github/workflows/network-none.yml
+++ b/.github/workflows/network-none.yml
@@ -8,9 +8,8 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
       with:
         cvmfs_repositories: 'singularity.opensciencegrid.org'
-    - uses: eic/run-cvmfs-osg-eic-shell@main
+    - uses: ./
       with:
-        run_local_checkout: 'true'
         platform-release: "jug_xl:nightly"
         network_types: "none"
         run: |

--- a/.github/workflows/network-none.yml
+++ b/.github/workflows/network-none.yml
@@ -17,3 +17,4 @@ jobs:
             false
           else
             true
+          fi

--- a/.github/workflows/network-none.yml
+++ b/.github/workflows/network-none.yml
@@ -1,0 +1,20 @@
+name: network-none
+on: [push, pull_request]
+jobs:
+  singularity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+      with:
+        cvmfs_repositories: 'singularity.opensciencegrid.org'
+    - uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        run_local_checkout: 'true'
+        platform-release: "jug_xl:nightly"
+        network_types: "none"
+        run: |
+          if ping -c 1 8.8.8.8 ; then
+            false
+          else
+            true

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The following parameters are supported:
  - `run`: They payload code you want to execute on top of the view
  - `setup`: Initialization/Setup script for a view that sets the environment (e.g. `/opt/detector/setup.sh`)
  - `sandbox-path`: Path where the setup script for the custom view is location. By specifying this variable the auto-resolving of the view based on `release` and `platform` is disabled.
+ - `network_types`: Network types to setup inside container. Defaults to `bridge` networking, but can be `none` to disable networking.
 
 Please be aware that you must use the combination of parameters `release` and `platform` together or use just the variable `platform-release` alone. These two options are given to enable more flexibility for the user to form their workflow with matrix expressions.
 

--- a/action.yml
+++ b/action.yml
@@ -32,10 +32,10 @@ inputs:
     description: 'Custom path where the sandbox is located'
     required: false
     default: ''
-  enable_network:
-    description: 'Enable network access inside EIC shell'
+  network_types:
+    description: 'Network access types inside EIC shell'
     required: false
-    default: true
+    default: 'bridge'
 
 runs:
   using: "composite"
@@ -57,4 +57,4 @@ runs:
         RUN: ${{ inputs.run }}
         SETUP: ${{ inputs.setup }}
         SANDBOX_PATH: ${{ inputs.sandbox-path }}
-        ENABLE_NETWORK: ${{ inputs.enable_network }}
+        NETWORK_TYPES: ${{ inputs.network_types }}

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Custom path where the sandbox is located'
     required: false
     default: ''
+  enable_network:
+    description: 'Enable network access inside EIC shell'
+    required: false
+    default: true
 
 runs:
   using: "composite"
@@ -53,3 +57,4 @@ runs:
         RUN: ${{ inputs.run }}
         SETUP: ${{ inputs.setup }}
         SANDBOX_PATH: ${{ inputs.sandbox-path }}
+        ENABLE_NETWORK: ${{ inputs.enable_network }}

--- a/action.yml
+++ b/action.yml
@@ -13,17 +13,13 @@ inputs:
     required: false
     default: ''
   platform-release:
-    description: 'LCG view release platform string you are targeting (e.g. jug_xl:3.0-stable)'
+    description: 'EIC shell release platform string you are targeting (e.g. jug_xl:3.0-stable)'
     required: false
     default: ''
   run:
     description: 'They payload code you want to execute on top of the view'
     required: false
     default: ''
-  run_local_checkout:
-    description: 'Run the local checkout of the action and not the main repo code'
-    required: false
-    default: 'false'
   setup:
     description: 'Environment initialization bash script that is sourced (e.g. install/setup.sh)'
     required: false
@@ -41,12 +37,7 @@ runs:
   using: "composite"
   steps:
     - run: |
-        if [ "${{ inputs.run_local_checkout }}" == "true" ]; then
-          echo "WARNING running local checkout of the action !"
-          .  setup-eic-shell.sh local
-        else
-          ${{ github.action_path }}/setup-eic-shell.sh
-        fi
+        ${{ github.action_path }}/setup-eic-shell.sh
       shell: bash
       env:
         THIS: ${{ github.action_path }}

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -48,7 +48,7 @@ if singularity instance list | grep ${worker} ; then
   echo "Reusing exisitng Singularity image from ${SANDBOX_PATH}"
  else
   echo "Starting Singularity image from ${SANDBOX_PATH}"
-  singularity instance start --bind /cvmfs --bind ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} ${SANDBOX_PATH} ${worker}
+  singularity instance start --bind /cvmfs --bind ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} --network ${NETWORK_TYPES:-bridge} ${SANDBOX_PATH} ${worker}
 fi
 
 echo "####################################################################"

--- a/setup-eic-shell.sh
+++ b/setup-eic-shell.sh
@@ -25,11 +25,7 @@ if [ -z "${SANDBOX_PATH}" ]; then
 fi
 
 if [ "$(uname)" == "Linux" ]; then
-  if [ "${1:-}" == "local" ]; then
-    . run-linux.sh
-  else
-    $THIS/run-linux.sh
-  fi
+  $THIS/run-linux.sh
 fi
 
 if [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
### Briefly, what does this PR introduce?
By passing the input argument `network_types`, the caller can set the network access available in the container. By setting this to `none`, no internet access will be available inside the container.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #8)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.