### PR TITLE
fix: more resiliency for apptainer latest version

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,18 @@
+name: version
+on: [push, pull_request]
+jobs:
+  singularity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+      with:
+        cvmfs_repositories: 'singularity.opensciencegrid.org'
+    - uses: ./
+      with:
+        platform-release: "jug_xl:nightly"
+        apptainer_version: "v1.1.2"
+        run: |
+          gcc --version
+          which gcc
+          eic-info

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following parameters are supported:
  - `setup`: Initialization/Setup script for a view that sets the environment (e.g. `/opt/detector/setup.sh`)
  - `sandbox-path`: Path where the setup script for the custom view is location. By specifying this variable the auto-resolving of the view based on `release` and `platform` is disabled.
  - `network_types`: Network types to setup inside container. Defaults to `bridge` networking, but can be `none` to disable networking.
+ - `apptainer_version`: Apptainer version to use. Defaults to `latest`, but can be any version such as `v1.1.3`.
 
 Please be aware that you must use the combination of parameters `release` and `platform` together or use just the variable `platform-release` alone. These two options are given to enable more flexibility for the user to form their workflow with matrix expressions.
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Network access types inside EIC shell'
     required: false
     default: 'bridge'
+  apptainer_version:
+    description: 'Apptainer version to use (e.g. v1.1.3 or latest)'
+    required: false
+    default: 'latest'
 
 runs:
   using: "composite"
@@ -49,3 +53,4 @@ runs:
         SETUP: ${{ inputs.setup }}
         SANDBOX_PATH: ${{ inputs.sandbox-path }}
         NETWORK_TYPES: ${{ inputs.network_types }}
+        APPTAINER_VERSION: ${{ inputs.apptainer_version }}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
There are isolated failures to curl the latest apptainer version. This is supposed to address that and can also be used to pin the apptainer version by the users.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.