### PR TITLE
fix: apptainer 1.1.4 requires privileged mode to set network

### DIFF
--- a/run-linux.sh
+++ b/run-linux.sh
@@ -56,7 +56,7 @@ sudo wget --quiet --timestamping --output-document /var/cache/apt/archives/${deb
 sudo apt-get -q -y install /var/cache/apt/archives/${deb}
 
 worker=$(echo ${SANDBOX_PATH} | sha256sum | awk '{print$1}')
-if apptainer instance list | grep ${worker} ; then
+if sudo apptainer instance list | grep ${worker} ; then
   echo "Reusing exisitng Apptainer image from ${SANDBOX_PATH}"
  else
   echo "Starting Apptainer image from ${SANDBOX_PATH}"

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -60,11 +60,11 @@ if apptainer instance list | grep ${worker} ; then
   echo "Reusing exisitng Apptainer image from ${SANDBOX_PATH}"
  else
   echo "Starting Apptainer image from ${SANDBOX_PATH}"
-  apptainer instance start --bind /cvmfs --bind ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} --network ${NETWORK_TYPES:-bridge} ${SANDBOX_PATH} ${worker}
+  sudo apptainer instance start --bind /cvmfs --bind ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} --network ${NETWORK_TYPES:-bridge} ${SANDBOX_PATH} ${worker}
 fi
 
 echo "####################################################################"
 echo "###################### Executing user payload ######################"
 echo "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV"
 
-apptainer exec instance://${worker} /bin/bash -c "cd ${GITHUB_WORKSPACE}; ./action_payload.sh"
+sudo apptainer exec instance://${worker} /bin/bash -c "cd ${GITHUB_WORKSPACE}; ./action_payload.sh"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Apptainer 1.1.4 requires privileged mode to set network to bridge mode. This ensure that the correct privilege is available when starting the container instance and connecting to it.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.