### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/organization.yml
+++ b/.github/workflows/organization.yml
@@ -1,5 +1,7 @@
 name: organization
 on: [push, pull_request, workflow_dispatch]
+permissions:
+  contents: read
 jobs:
   singularity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/eic/run-cvmfs-osg-eic-shell/security/code-scanning/4](https://github.com/eic/run-cvmfs-osg-eic-shell/security/code-scanning/4)

Add an explicit `permissions` block in `.github/workflows/organization.yml` at the workflow root so it applies to all jobs (including `singularity`) unless overridden.  
Best minimal fix (without changing existing functionality) is:

- Add:
  - `permissions:`
  - `  contents: read`

Place it after the `on:` line and before `jobs:`. This satisfies CodeQL’s requirement and enforces least privilege baseline for the token. No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
