### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,5 +1,7 @@
 name: linux
 on: [push, pull_request, workflow_dispatch]
+permissions:
+  contents: read
 jobs:
   singularity:
     runs-on: ubuntu-latest

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -2,6 +2,7 @@ name: linux
 on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
+  actions: write
 jobs:
   singularity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/eic/run-cvmfs-osg-eic-shell/security/code-scanning/3](https://github.com/eic/run-cvmfs-osg-eic-shell/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/basic.yml` at the workflow root (recommended here since there is one job). Use least privilege as baseline:

- `contents: read`

This preserves current functionality for checkout and read-only operations while preventing unintended broader token access inherited from defaults. If later you discover a step needs extra scopes, add only the specific required permission (for example `packages: read`), but do not grant broad write access preemptively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
