### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,5 +1,7 @@
 name: version
 on: [push, pull_request, workflow_dispatch]
+permissions:
+  contents: read
 jobs:
   singularity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/eic/run-cvmfs-osg-eic-shell/security/code-scanning/2](https://github.com/eic/run-cvmfs-osg-eic-shell/security/code-scanning/2)

To fix this, add an explicit `permissions` block in `.github/workflows/version.yml` at the workflow root (preferred here since there is only one job and no job-specific overrides shown). The minimal required scope for this workflow is `contents: read`, which supports checkout while preventing unnecessary write access.

Best single fix without changing functionality:
- Edit `.github/workflows/version.yml`
- Insert right after the `on:` line:
  - `permissions:`
  - `  contents: read`

No new methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
