### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/double.yml
+++ b/.github/workflows/double.yml
@@ -1,4 +1,6 @@
 name: double
+permissions:
+  contents: read
 on: [push, pull_request, workflow_dispatch]
 jobs:
   singularity:


### PR DESCRIPTION
Potential fix for [https://github.com/eic/run-cvmfs-osg-eic-shell/security/code-scanning/1](https://github.com/eic/run-cvmfs-osg-eic-shell/security/code-scanning/1)

To fix this, add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained by default. The best minimal fix without changing functionality is to set workflow-level permissions to read-only for repository contents.

In `.github/workflows/double.yml`, add:

```yml
permissions:
  contents: read
```

directly under `name` (before `on` is typical). This applies to all jobs in the workflow unless overridden and satisfies CodeQL’s recommendation with least privilege. No additional imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
