### PR TITLE
fix: revert back to default `apptainer_version: latest`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
   apptainer_version:
     description: 'Apptainer version to use (e.g. v1.4.5 or latest)'
     required: false
-    default: 'v1.4.5'
+    default: 'latest'
   apptainer_deb_cache:
     description: 'Location (directory) of the cached apptainer deb.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -48,11 +48,25 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve Apptainer version
+      id: resolve-apptainer-version
+      shell: bash
+      run: |
+        if [[ "${{ inputs.apptainer_version }}" == "latest" ]] ; then
+          v=$(curl -sL --retry 5 https://api.github.com/repos/apptainer/apptainer/releases/latest | jq -r ".tag_name")
+          while [[ ${v} == "null" ]] ; do
+            sleep 5
+            v=$(curl -sL --retry 5 https://api.github.com/repos/apptainer/apptainer/releases/latest | jq -r ".tag_name")
+          done
+        else
+          v="${{ inputs.apptainer_version }}"
+        fi
+        echo "apptainer_version=${v}" >> $GITHUB_OUTPUT
     - name: Restore cached apptainer package
       id: cache-restore
       uses: actions/cache@v5
       with:
-        key: apptainer-deb-cache-${{ inputs.apptainer_version }}
+        key: apptainer-deb-cache-${{ steps.resolve-apptainer-version.outputs.apptainer_version }}
         path: |
           ${{ inputs.apptainer_deb_cache }}
     - name: Run inside eic-shell
@@ -72,11 +86,11 @@ runs:
         SETUP: ${{ inputs.setup }}
         SANDBOX_PATH: ${{ inputs.sandbox-path }}
         APPTAINER_DEB_CACHE: ${{ inputs.apptainer_deb_cache }}
-        APPTAINER_VERSION: ${{ inputs.apptainer_version }}
+        APPTAINER_VERSION: ${{ steps.resolve-apptainer-version.outputs.apptainer_version }}
     - name: Store apptainer package to cache
       uses: actions/cache/save@v5
-      if: steps.run-eic-shell.outputs.cache-update == 'true'      
+      if: steps.run-eic-shell.outputs.cache-update == 'true'
       with:
-        key: apptainer-deb-cache-${{ inputs.apptainer_version }}
+        key: apptainer-deb-cache-${{ steps.resolve-apptainer-version.outputs.apptainer_version }}
         path: |
           ${{ inputs.apptainer_deb_cache }}

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -44,16 +44,7 @@ ${RUN}
 " > ${GITHUB_WORKSPACE}/action_payload.sh
 chmod a+x ${GITHUB_WORKSPACE}/action_payload.sh
 
-if [[ ${APPTAINER_VERSION} == "latest" ]] ; then
-  v=$(curl -sL --retry 5 https://api.github.com/repos/apptainer/apptainer/releases/latest | jq -r ".tag_name")
-  # the curl above is fragile, so retry until successful
-  while [[ ${v} == "null" ]] ; do
-    sleep 5
-    v=$(curl -sL --retry 5 https://api.github.com/repos/apptainer/apptainer/releases/latest | jq -r ".tag_name")
-  done
-else
-  v=${APPTAINER_VERSION}
-fi
+v=${APPTAINER_VERSION}
 
 echo "::group::Installing Apptainer ${v}"
 for deb in "apptainer_${v/v/}_amd64.deb" "apptainer-suid_${v/v/}_amd64.deb"; do


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Now that apptainer v1.5.0 is out, we don't pick it up automatically since we are pinned to v1.4.5.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: unpin apptainer)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
